### PR TITLE
PR 1: Fix simple typos

### DIFF
--- a/R/d_calc.R
+++ b/R/d_calc.R
@@ -28,7 +28,7 @@
 #' \dontrun{
 #' library(dplyr)
 #' PaluckMetaSOP::contact_data |>
-#' select(-d) |>.# remove d in order to recalculate it
+#' select(-d) |> # remove d in order to recalculate it
 #' mutate(d = mapply(
 #' FUN = d_calc,
 #' stat_type = statistic,

--- a/R/map_robust.R
+++ b/R/map_robust.R
@@ -19,7 +19,7 @@
 #' @examples
 #' # example 1: meta-analyze entire dataset
 #' PaluckMetaSOP::sv_data |> map_robust()
-#' # example 2: meta-analyze many subsetes and create overall table
+#' # example 2: meta-analyze many subsets and create overall table
 #' \dontrun{
 #' library(dplyr); library(purrr)
 #' sv_data |> split(~behavior_type) |> map(map_robust) |>

--- a/R/var_d_calc.R
+++ b/R/var_d_calc.R
@@ -5,7 +5,7 @@
 #' You can calculate variance on an individual basis by manually putting in a d value
 #' from d_calc(), or you can do so in a batch way based on an entire dataset.
 #'
-#' @param d Standardized effect size calculated using `d_calc.R`.
+#' @param d Standardized effect size calculated using `d_calc()`.
 #' @param n_t Treatment sample size.
 #' @param n_c Control group sample size.
 #' @return Variance of Cohen's D or Glass's Delta

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run the following R Command:
 ## What you'll find:
 This package, functions, vignettes, and two datasets.
 
-The functions implement the Paluck lab approach to meta-analyiss.
+The functions implement the Paluck lab approach to meta-analysis.
 
 The vignettes walk through how to use the functions.
 

--- a/vignettes/d-calc-vignette.Rmd
+++ b/vignettes/d-calc-vignette.Rmd
@@ -182,7 +182,7 @@ Notice that we record the DiD calculation in the code itself for reproducibility
 
 #### 3.1.3 Regression coefficient (beta):
 
-In a bivariate regression testing the relationship between treatment status and outcome, the $\beta$ coefficient is is equivalent to the difference in means between the groups. Calculating the $SD$ from a regression table takes some guesswork (see [section 4](#section4)), but some studies report both $\beta$ and the $SD$ for the outcome.
+In a bivariate regression testing the relationship between treatment status and outcome, the $\beta$ coefficient is equivalent to the difference in means between the groups. Calculating the $SD$ from a regression table takes some guesswork (see [section 4](#section4)), but some studies report both $\beta$ and the $SD$ for the outcome.
 
 [Boisjoly et al. (2006)](https://www.aeaweb.org/articles?id=10.1257/aer.96.5.1890) tested the effects of being randomly assigned a black or "other minority" roommate on the attitudes and behaviors of white college students.
 

--- a/vignettes/meta-analysis-vignette.Rmd
+++ b/vignettes/meta-analysis-vignette.Rmd
@@ -64,7 +64,7 @@ If you want to cluster at a different level, or call your cluster variable somet
 
 ## 2 subgroup analyses
 
-The second way we use `map_robust` is via subgroup analyses. For instance, in "Preventing Sexual Violence," we wanted to compare the results on ideas-based outcomes to our major categories of behavioral outcomes (perpetration, victimization, bystander behaviors, and involvement behaviors.) To do this,we use the `map` function from the `purrr` library to split the dataset and apply a function (Hadley Wickham calls this  "[The Split-Apply-Combine Strategy for Data Analysis](https://vita.had.co.nz/papers/plyr.pdf)").
+The second way we use `map_robust` is via subgroup analyses. For instance, in "Preventing Sexual Violence," we wanted to compare the results on ideas-based outcomes to our major categories of behavioral outcomes (perpetration, victimization, bystander behaviors, and involvement behaviors.) To do this, we use the `map` function from the `purrr` library to split the dataset and apply a function (Hadley Wickham calls this  "[The Split-Apply-Combine Strategy for Data Analysis](https://vita.had.co.nz/papers/plyr.pdf)").
 
 
 ```{r split_by_behavioral_ideas_outcomes}

--- a/vignettes/meta-analysis-vignette.Rmd
+++ b/vignettes/meta-analysis-vignette.Rmd
@@ -60,7 +60,7 @@ robust(x = metafor::rma(yi = contact_data$d, vi = contact_data$var_d), cluster =
 rma(yi = d, vi = var_d, data = contact_data)
 ```
 
-If you want to cluster at a different level, or call your cluster variable something different and modify the function accordingly, go ahead! Every meta-analysis is different, and we encourage you to to modify these functions to serve your own needs. (We typically have a `functions` folder in our replication archives where we keep all our custom functions, which is a nice way to keep your function files organized separately from your scripts.)
+If you want to cluster at a different level, or call your cluster variable something different and modify the function accordingly, go ahead! Every meta-analysis is different, and we encourage you to modify these functions to serve your own needs. (We typically have a `functions` folder in our replication archives where we keep all our custom functions, which is a nice way to keep your function files organized separately from your scripts.)
 
 ## 2 subgroup analyses
 


### PR DESCRIPTION
## Summary
This PR fixes several simple typos found throughout the package:

- **README.md**: "meta-analyiss" → "meta-analysis"
- **R/d_calc.R**: Added missing space in code comment
- **R/var_d_calc.R**: "d_calc.R" → "d_calc()"
- **R/map_robust.R**: "subsetes" → "subsets"
- **vignettes/d-calc-vignette.Rmd**: "is is" → "is"
- **vignettes/meta-analysis-vignette.Rmd**: "to to" → "to", missing space after comma

## Rationale
These are straightforward spelling and grammar corrections that improve documentation clarity without changing any functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)