### PR TITLE
Seth has no idea how to write HTML but Claude does 😃 in d-calc vignette

### DIFF
--- a/vignettes/d-calc-vignette.Rmd
+++ b/vignettes/d-calc-vignette.Rmd
@@ -361,9 +361,7 @@ Some studies, e.g. [Hall 1969](https://ir-api.ua.edu/api/core/bitstreams/8b53661
 
 `d_calc("unspecified_null")` will always return 0.01 no matter the values of the other parameters.
 
-\<a name="section4"\>\</a\>
-
-## 4 Hard cases: non-standard conversions of results into SMDs
+## 4 Hard cases: non-standard conversions of results into SMDs {#section4}
 
 Each of our meta-analyses has had edge cases that required bespoke solutions. Here we'll walk through two: figuring out ∆ when the meta-analytic outcome is different than the one the paper focuses on; and estimating an SMD from a regression table.
 


### PR DESCRIPTION
Replaced the improperly escaped HTML anchor `\<a name="section4"\>\</a\>` with proper R Markdown anchor syntax `{#section4}` on the heading itself.

This ensures that internal links to [section 4](#section4) will render correctly in the HTML vignette output, matching the style already used for section 3.2.3 (#section323).

Benefits:
- Cleaner markdown syntax
- Proper anchor rendering in HTML output
- Consistent with R Markdown best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)