### PR TITLE
PR 3: Improve function documentation

### DIFF
--- a/R/PaluckMetaSOP-package.R
+++ b/R/PaluckMetaSOP-package.R
@@ -35,8 +35,8 @@
 #' respectively.
 #'
 #' Please install this package with vignettes included via
-#' `remotes::install('setgree/PaluckMetaSOP', build_vignettes = T)`.
-#' You can then browse the vignettes with  `browseVignettes('PaluckMetaSOP')`.
+#' `remotes::install_github('setgree/PaluckMetaSOP', build_vignettes = TRUE)`.
+#' You can then browse the vignettes with `browseVignettes('PaluckMetaSOP')`.
 #'
 #' @name PaluckMetaSOP-package
 #' @aliases PaluckMetaSOP

--- a/R/d_calc.R
+++ b/R/d_calc.R
@@ -16,6 +16,8 @@
 #' @param n_t Treatment group sample size.
 #' @param n_c Control group sample size.
 #' @return Cohen's D or Glass's Delta value.
+#' @family effect size functions
+#' @seealso \code{\link{var_d_calc}} for calculating the variance of effect sizes
 #'
 #' @export
 #'

--- a/R/map_robust.R
+++ b/R/map_robust.R
@@ -16,6 +16,7 @@
 #'
 #' @param x The dataset or subset to perform meta-analysis on.
 #' @return A tibble with meta-analysis results.
+#' @seealso \code{\link{d_calc}} and \code{\link{var_d_calc}} for preparing data before meta-analysis
 #' @examples
 #' # example 1: meta-analyze entire dataset
 #' PaluckMetaSOP::sv_data |> map_robust()

--- a/R/study_count.R
+++ b/R/study_count.R
@@ -6,6 +6,8 @@
 #' @param dataset The dataset or subset.
 #' @param counting_var The variable to count unique observations (default: "unique_study_id").
 #' @return A tibble with the count of distinct observations.
+#' @family summary functions
+#' @seealso \code{\link{sum_tab}} for frequency tables, \code{\link{sum_lm}} for regression summaries
 #' @importFrom dplyr summarise
 #' @importFrom dplyr n_distinct
 #' @importFrom rlang sym

--- a/R/sum_lm.R
+++ b/R/sum_lm.R
@@ -13,7 +13,10 @@
 #' @param dgts Number of digits for rounding coefficients (default: 5).
 #' @return If coefs_only is TRUE, returns a rounded coefficients table; otherwise, returns the full summary.
 #' @importFrom stats lm as.formula
-#' @note `dat` is the default dataset name, but you can put in whatever
+#' @note The function defaults to using `d` as the response variable and `se_d` as the predictor
+#' if these columns exist in the dataset. You can override these by specifying `y` and `x` parameters.
+#' @family summary functions
+#' @seealso \code{\link{sum_tab}} for frequency tables, \code{\link{study_count}} for counting studies
 #' @export
 #'
 #' @examples

--- a/R/sum_tab.R
+++ b/R/sum_tab.R
@@ -9,7 +9,9 @@
 #' @param data A data frame or tibble.
 #' @param var_name The name of the variable/column to generate the frequency table.
 #' @return A table showing the frequency of each unique value in the specified variable.
-#'#'
+#' @family summary functions
+#' @seealso \code{\link{sum_lm}} for regression summaries, \code{\link{study_count}} for counting studies
+#'
 #' @importFrom dplyr pull
 #' @importFrom rlang !! enquo
 #' @export

--- a/R/var_d_calc.R
+++ b/R/var_d_calc.R
@@ -9,6 +9,8 @@
 #' @param n_t Treatment sample size.
 #' @param n_c Control group sample size.
 #' @return Variance of Cohen's D or Glass's Delta
+#' @family effect size functions
+#' @seealso \code{\link{d_calc}} for calculating effect sizes
 #' @export
 #' @examples
 #' #  example 1: calculating d, var_d, and se_d for a single study


### PR DESCRIPTION
## Summary
Enhances roxygen documentation across all package functions with better cross-references and several corrections.

## Changes

### Fixes
- **sum_tab.R**: Removed duplicate roxygen comment marker (`#'#'` → `#'`)
- **sum_lm.R**: Corrected `@note` to accurately describe default behavior (was "dat" but parameter is "dataset")
- **PaluckMetaSOP-package.R**: Fixed installation instruction (`install()` → `install_github()`)

### Enhancements
- Added `@family` tags to group related functions:
  - "effect size functions" for `d_calc()` and `var_d_calc()`
  - "summary functions" for `sum_lm()`, `sum_tab()`, and `study_count()`
- Added `@seealso` tags to cross-reference related functions throughout the package
- Improved discoverability when browsing documentation with `?function_name`

## Benefits
- Users can now easily discover related functions when viewing help pages
- Function families are clearly grouped in the documentation index
- Installation instructions are now correct
- Documentation is cleaner and more professional

🤖 Generated with [Claude Code](https://claude.com/claude-code)