### PR TITLE
PR 7: Fix critical statistical formula error and improve documentation

### DIFF
--- a/R/d_calc.R
+++ b/R/d_calc.R
@@ -70,7 +70,7 @@ d_calc <- function(stat_type, stat, sample_sd, n_t, n_c) {
     # Calculate Glass's Delta for difference in proportions
     # "SD" as an input is a misnomer here; input the _proportion_ of the incident
     # in the control group as the variance estimate, and then this calculator
-    # treats that as draws from a Bernoulli distribution. Variance ouf Bernoulli
+    # treats that as draws from a Bernoulli distribution. Variance of Bernoulli
     # is $p(1-p)$; so the estimator in total is
     #  $$\Delta = \frac{p_{1} - p_{2}}{\sqrt{p_{2} * (1 - p_{2)}}}$$
     d = stat / (sqrt(sample_sd * (1 - sample_sd)))

--- a/vignettes/d-calc-vignette.Rmd
+++ b/vignettes/d-calc-vignette.Rmd
@@ -94,9 +94,9 @@ To see all the conversion formulas, run `PaluckMetaSOP::d_calc` (without parenth
 
 The function first turns this into an (uncorrected) estimate of variance via
 
-${\sigma^2_1} = (\frac{n_t + n_c}{n_t * n_c}) + (\frac{d^2}{2} * (n_t + n_c))$
+${\sigma^2_1} = \frac{n_t + n_c}{n_t \cdot n_c} + \frac{d^2}{2(n_t + n_c)}$
 
-And then applies a correction for small study variance called hedge's *g:*
+And then applies a correction for small sample size called Hedge's *g:*
 
 $g = 1 - (3/((4 * (n_t + n_c - 2)) - 1))$
 
@@ -288,7 +288,7 @@ Neither of these estimators came up in [The Contact Hypothesis Re-evaluated](htt
 
 [^6]: [Chen, Cohen & Chen (2010)](https://www.tandfonline.com/doi/full/10.1080/03610911003650383) propose that if incidence of a disease is 1% within a control group, then "OR = 1.68, 3.47, and 6.71 are equivalent to Cohen's \$d\$ = 0.2 (small), 0.5 (medium), and 0.8 (large), respectively'' (p. 862), with different proportions corresponding to equivalent effect sizes at a range of incidence rates. However, the populations and dependent variables in our meta-analyses are generally too heterogeneous for these sorts of heuristics.
 
-As a solution to this, while we were working on [Prejudice Reduction: Progress and Challenges](https://www.annualreviews.org/content/journals/10.1146/annurev-psych-071620-030619), Donald P. Green proposed a solution that treats those proportions as draws form a Bernoulli distribution and calculates variance and $SD$ accordingly.
+As a solution to this, while we were working on [Prejudice Reduction: Progress and Challenges](https://www.annualreviews.org/content/journals/10.1146/annurev-psych-071620-030619), Donald P. Green proposed treating those proportions as draws from a Bernoulli distribution and calculating variance and $SD$ accordingly.
 
 The $SD$ of the Bernoulli distribution is $$
 \sqrt{ p (1-p)}


### PR DESCRIPTION
## Summary
Fixes a **critical mathematical error** in the vignette's variance formula documentation, plus several other improvements to statistical documentation.

## CRITICAL FIX - Variance Formula

The vignette documentation had a serious error in the variance formula:

**Incorrect (vignette):**
```
σ²₁ = (n_t + n_c)/(n_t * n_c) + (d²/2) * (n_t + n_c)
```
The second term shows MULTIPLICATION by (n_t + n_c)

**Correct (now fixed):**
```
σ²₁ = (n_t + n_c)/(n_t * n_c) + d²/(2(n_t + n_c))
```
The second term should DIVIDE by (n_t + n_c)

**Note:** The R code in `var_d_calc()` was always correct - only the vignette documentation had the error. But this could have seriously misled readers trying to implement the formula themselves.

## Other Improvements

- Improved LaTeX formatting using `\cdot` for multiplication (clearer than `*`)
- Fixed "small study variance" → "small sample size" (more accurate terminology)
- Fixed capitalization: "hedge's g" → "Hedge's g" (proper name)
- Fixed typo in code comment: "ouf" → "of" 
- Fixed typo in vignette: "form" → "from" (draws from a Bernoulli)
- Improved sentence flow: removed redundant "solution...solution" wording

## Formula Verification

All formulas in the vignette were checked against the actual code:
- ✓ Variance calculation formula (FIXED)
- ✓ t-test conversion formula 
- ✓ F-test conversion formula
- ✓ Difference in proportions formula
- ✓ All other statistical conversions

This ensures users reading the vignettes see mathematically correct formulas that match the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)