### PR TITLE
PR 9: Fix R CMD check NOTEs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^\.claude$
+^.*\.tar\.gz$


### PR DESCRIPTION
## Summary
Fixes the two NOTEs reported by `devtools::check()`.

## Changes

### 1. Hidden Files/Directories NOTE
**Problem:** `.claude` directory was being included in package builds

**Solution:** Added to `.Rbuildignore`:
```
^\.claude$
^.*\.tar\.gz$
```

Also excluded `.tar.gz` files (build artifacts that shouldn't be in the repo).

### 2. License Stub NOTE
**Problem:** DESCRIPTION had `License: MIT` which is just a stub

**Solution:** This was already fixed in a previous PR that changed it to:
```
License: MIT + file LICENSE
```

This properly references the full MIT license text in the `LICENSE` file.

## Testing
After these changes, running `devtools::check()` should complete without these NOTEs.

## Why This Matters
- Clean `R CMD check` is required for CRAN submission
- Hidden files shouldn't be distributed with the package
- Proper license specification is important for legal clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)