### PR TITLE
Add comprehensive unit tests for core functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     metafor (>= 4.6),
     rlang (>= 1.1),
     tibble (>= 3.2)
-Suggests: 
+Suggests:
     forcats (>= 1.0),
     ggthemes (>= 5.1),
     ggplot2 (>= 3.5),
@@ -29,6 +29,7 @@ Suggests:
     RefManageR (>= 1.4),
     rmarkdown (>= 2.26),
     stringr (>= 1.5),
+    testthat (>= 3.0.0),
     tidyr (>= 1.3)
 VignetteBuilder: 
     knitr

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/tests.html
+# * https://testthat.r-lib.org/reference/test_package.html#special-files
+
+library(testthat)
+library(PaluckMetaSOP)
+
+test_check("PaluckMetaSOP")

--- a/tests/testthat/test-d_calc.R
+++ b/tests/testthat/test-d_calc.R
@@ -1,0 +1,106 @@
+test_that("d_calc handles stat_type 'd' correctly", {
+  result <- d_calc(stat_type = "d", stat = 0.5, sample_sd = NA, n_t = NA, n_c = NA)
+  expect_equal(result, 0.5)
+})
+
+test_that("d_calc handles stat_type 's_m_d' correctly", {
+  result <- d_calc(stat_type = "s_m_d", stat = 0.3, sample_sd = NA, n_t = NA, n_c = NA)
+  expect_equal(result, 0.3)
+})
+
+test_that("d_calc handles stat_type 'd_i_m' correctly", {
+  result <- d_calc(stat_type = "d_i_m", stat = 1, sample_sd = 0.3, n_t = NA, n_c = NA)
+  expect_equal(result, round(1 / 0.3, digits = 3))
+})
+
+test_that("d_calc handles stat_type 'd_i_d' correctly", {
+  result <- d_calc(stat_type = "d_i_d", stat = 0.5, sample_sd = 0.25, n_t = NA, n_c = NA)
+  expect_equal(result, round(0.5 / 0.25, digits = 3))
+})
+
+test_that("d_calc handles stat_type 'reg_coef' correctly", {
+  result <- d_calc(stat_type = "reg_coef", stat = 0.6, sample_sd = 0.2, n_t = NA, n_c = NA)
+  expect_equal(result, round(0.6 / 0.2, digits = 3))
+})
+
+test_that("d_calc handles stat_type 'regression' correctly", {
+  result <- d_calc(stat_type = "regression", stat = 0.4, sample_sd = 0.1, n_t = NA, n_c = NA)
+  expect_equal(result, round(0.4 / 0.1, digits = 3))
+})
+
+test_that("d_calc handles stat_type 'beta' correctly", {
+  result <- d_calc(stat_type = "beta", stat = 0.3, sample_sd = 0.15, n_t = NA, n_c = NA)
+  expect_equal(result, round(0.3 / 0.15, digits = 3))
+})
+
+test_that("d_calc handles stat_type 't_test' correctly", {
+  result <- d_calc(stat_type = "t_test", stat = 2, sample_sd = NA, n_t = 50, n_c = 40)
+  expected <- round(2 * sqrt((50 + 40) / (50 * 40)), digits = 3)
+  expect_equal(result, expected)
+})
+
+test_that("d_calc handles stat_type 'T-test' correctly", {
+  result <- d_calc(stat_type = "T-test", stat = 1.5, sample_sd = NA, n_t = 30, n_c = 30)
+  expected <- round(1.5 * sqrt((30 + 30) / (30 * 30)), digits = 3)
+  expect_equal(result, expected)
+})
+
+test_that("d_calc handles stat_type 'f_test' correctly", {
+  result <- d_calc(stat_type = "f_test", stat = 4, sample_sd = NA, n_t = 50, n_c = 40)
+  expected <- round(sqrt((4 * (50 + 40)) / (50 * 40)), digits = 3)
+  expect_equal(result, expected)
+})
+
+test_that("d_calc handles stat_type 'F-test' correctly", {
+  result <- d_calc(stat_type = "F-test", stat = 3, sample_sd = NA, n_t = 25, n_c = 25)
+  expected <- round(sqrt((3 * (25 + 25)) / (25 * 25)), digits = 3)
+  expect_equal(result, expected)
+})
+
+test_that("d_calc handles stat_type 'F' correctly", {
+  result <- d_calc(stat_type = "F", stat = 2.5, sample_sd = NA, n_t = 40, n_c = 60)
+  expected <- round(sqrt((2.5 * (40 + 60)) / (40 * 60)), digits = 3)
+  expect_equal(result, expected)
+})
+
+test_that("d_calc handles stat_type 'odds_ratio' correctly", {
+  result <- d_calc(stat_type = "odds_ratio", stat = 2, sample_sd = NA, n_t = NA, n_c = NA)
+  expected <- log(2) * sqrt(3) / pi
+  expect_equal(result, expected)
+})
+
+test_that("d_calc handles stat_type 'log_odds_ratio' correctly", {
+  result <- d_calc(stat_type = "log_odds_ratio", stat = 0.5, sample_sd = NA, n_t = NA, n_c = NA)
+  expected <- 0.5 * sqrt(3) / pi
+  expect_equal(result, expected)
+})
+
+test_that("d_calc handles stat_type 'd_i_p' correctly", {
+  result <- d_calc(stat_type = "d_i_p", stat = 0.2, sample_sd = 0.5, n_t = NA, n_c = NA)
+  expected <- 0.2 / sqrt(0.5 * (1 - 0.5))
+  expect_equal(result, expected)
+})
+
+test_that("d_calc handles stat_type 'unspecified_null' correctly", {
+  result <- d_calc(stat_type = "unspecified_null", stat = NA, sample_sd = NA, n_t = NA, n_c = NA)
+  expect_equal(result, 0.01)
+})
+
+test_that("d_calc handles stat_type 'unspecified null' correctly", {
+  result <- d_calc(stat_type = "unspecified null", stat = NA, sample_sd = NA, n_t = NA, n_c = NA)
+  expect_equal(result, 0.01)
+})
+
+test_that("d_calc returns NA for unrecognized stat_type", {
+  result <- d_calc(stat_type = "invalid_type", stat = 1, sample_sd = 0.3, n_t = 50, n_c = 40)
+  expect_true(is.na(result))
+})
+
+test_that("d_calc example from documentation works", {
+  result <- d_calc(stat_type = "d_i_m", stat = 1, sample_sd = 0.3)
+  expect_equal(result, round(1 / 0.3, digits = 3))
+
+  result2 <- d_calc(stat_type = "f_test", stat = 1, n_t = 50, n_c = 40)
+  expected2 <- round(sqrt((1 * (50 + 40)) / (50 * 40)), digits = 3)
+  expect_equal(result2, expected2)
+})

--- a/tests/testthat/test-study_count.R
+++ b/tests/testthat/test-study_count.R
@@ -1,0 +1,108 @@
+test_that("study_count counts unique studies correctly", {
+  test_data <- data.frame(
+    unique_study_id = c(1, 1, 2, 3, 2, 1, 3),
+    other_var = c("a", "b", "c", "d", "e", "f", "g")
+  )
+
+  result <- study_count(test_data)
+
+  expect_s3_class(result, "data.frame")
+  expect_true("N_unique" %in% names(result))
+  expect_equal(result$N_unique, 3)
+})
+
+test_that("study_count works with tibbles", {
+  test_data <- tibble::tibble(
+    unique_study_id = c(10, 20, 30, 10, 20),
+    value = c(100, 200, 300, 400, 500)
+  )
+
+  result <- study_count(test_data)
+
+  expect_s3_class(result, "data.frame")
+  expect_equal(result$N_unique, 3)
+})
+
+test_that("study_count handles single unique value", {
+  test_data <- data.frame(
+    unique_study_id = c(1, 1, 1, 1, 1)
+  )
+
+  result <- study_count(test_data)
+
+  expect_equal(result$N_unique, 1)
+})
+
+test_that("study_count handles all unique values", {
+  test_data <- data.frame(
+    unique_study_id = c(1, 2, 3, 4, 5)
+  )
+
+  result <- study_count(test_data)
+
+  expect_equal(result$N_unique, 5)
+})
+
+test_that("study_count works with custom counting variable", {
+  test_data <- data.frame(
+    unique_study_id = c(1, 1, 2, 2, 3),
+    custom_id = c("A", "A", "B", "C", "C")
+  )
+
+  result <- study_count(test_data, counting_var = "custom_id")
+
+  expect_equal(result$N_unique, 3)
+})
+
+test_that("study_count works with character IDs", {
+  test_data <- data.frame(
+    unique_study_id = c("study1", "study2", "study1", "study3", "study2", "study1")
+  )
+
+  result <- study_count(test_data)
+
+  expect_equal(result$N_unique, 3)
+})
+
+test_that("study_count works with included dataset", {
+  result <- study_count(PaluckMetaSOP::sv_data)
+
+  expect_s3_class(result, "data.frame")
+  expect_true("N_unique" %in% names(result))
+  expect_true(result$N_unique > 0)
+  expect_true(result$N_unique <= nrow(PaluckMetaSOP::sv_data))
+})
+
+test_that("study_count handles NA values correctly", {
+  test_data <- data.frame(
+    unique_study_id = c(1, 2, NA, 1, 3, NA)
+  )
+
+  result <- study_count(test_data)
+
+  expect_s3_class(result, "data.frame")
+  expect_true(result$N_unique >= 3)  # At least 1, 2, 3 (NA may or may not be counted)
+})
+
+test_that("study_count returns a data frame with correct structure", {
+  test_data <- data.frame(
+    unique_study_id = c(1, 2, 3, 1, 2)
+  )
+
+  result <- study_count(test_data)
+
+  expect_s3_class(result, "data.frame")
+  expect_equal(ncol(result), 1)
+  expect_equal(nrow(result), 1)
+  expect_equal(names(result), "N_unique")
+})
+
+test_that("study_count works with factor variables", {
+  test_data <- data.frame(
+    unique_study_id = factor(c("A", "B", "A", "C", "B", "A"))
+  )
+
+  result <- study_count(test_data)
+
+  expect_equal(result$N_unique, 3)
+})

--- a/tests/testthat/test-sum_tab.R
+++ b/tests/testthat/test-sum_tab.R
@@ -1,0 +1,96 @@
+test_that("sum_tab creates frequency table for simple data", {
+  test_data <- data.frame(
+    category = c("A", "B", "A", "C", "B", "A")
+  )
+
+  result <- sum_tab(test_data, category)
+
+  expect_s3_class(result, "table")
+  expect_equal(as.numeric(result["A"]), 3)
+  expect_equal(as.numeric(result["B"]), 2)
+  expect_equal(as.numeric(result["C"]), 1)
+})
+
+test_that("sum_tab works with factor variables", {
+  test_data <- data.frame(
+    status = factor(c("active", "inactive", "active", "active", "inactive"))
+  )
+
+  result <- sum_tab(test_data, status)
+
+  expect_s3_class(result, "table")
+  expect_equal(as.numeric(result["active"]), 3)
+  expect_equal(as.numeric(result["inactive"]), 2)
+})
+
+test_that("sum_tab works with numeric variables", {
+  test_data <- data.frame(
+    value = c(1, 2, 1, 3, 2, 1, 2)
+  )
+
+  result <- sum_tab(test_data, value)
+
+  expect_s3_class(result, "table")
+  expect_equal(as.numeric(result["1"]), 3)
+  expect_equal(as.numeric(result["2"]), 3)
+  expect_equal(as.numeric(result["3"]), 1)
+})
+
+test_that("sum_tab handles single unique value", {
+  test_data <- data.frame(
+    same = c("X", "X", "X", "X")
+  )
+
+  result <- sum_tab(test_data, same)
+
+  expect_s3_class(result, "table")
+  expect_equal(length(result), 1)
+  expect_equal(as.numeric(result["X"]), 4)
+})
+
+test_that("sum_tab handles all unique values", {
+  test_data <- data.frame(
+    unique_vals = c("A", "B", "C", "D")
+  )
+
+  result <- sum_tab(test_data, unique_vals)
+
+  expect_s3_class(result, "table")
+  expect_equal(length(result), 4)
+  expect_true(all(result == 1))
+})
+
+test_that("sum_tab works with tibbles", {
+  test_data <- tibble::tibble(
+    category = c("X", "Y", "X", "Z", "Y", "X")
+  )
+
+  result <- sum_tab(test_data, category)
+
+  expect_s3_class(result, "table")
+  expect_equal(as.numeric(result["X"]), 3)
+  expect_equal(as.numeric(result["Y"]), 2)
+  expect_equal(as.numeric(result["Z"]), 1)
+})
+
+test_that("sum_tab works with included dataset", {
+  # Use the sv_data from the package
+  result <- sum_tab(PaluckMetaSOP::sv_data, behavior_type)
+
+  expect_s3_class(result, "table")
+  expect_true(length(result) > 0)
+  expect_true(sum(result) == nrow(PaluckMetaSOP::sv_data))
+})
+
+test_that("sum_tab handles NA values correctly", {
+  test_data <- data.frame(
+    category = c("A", "B", NA, "A", "B", NA)
+  )
+
+  result <- sum_tab(test_data, category)
+
+  expect_s3_class(result, "table")
+  # table() includes NA as a separate category
+  expect_true("A" %in% names(result))
+  expect_true("B" %in% names(result))
+})

--- a/tests/testthat/test-var_d_calc.R
+++ b/tests/testthat/test-var_d_calc.R
@@ -1,0 +1,93 @@
+test_that("var_d_calc calculates variance correctly for basic inputs", {
+  # Test with d = 0.5, n_t = 50, n_c = 50
+  d <- 0.5
+  n_t <- 50
+  n_c <- 50
+
+  # Manual calculation
+  ust_var_d <- ((n_t + n_c) / (n_t * n_c)) + ((d^2) / (2 * (n_t + n_c)))
+  hedge_g <- 1 - (3 / ((4 * (n_t + n_c - 2)) - 1))
+  expected <- round((hedge_g^2) * ust_var_d, digits = 3)
+
+  result <- var_d_calc(d = d, n_t = n_t, n_c = n_c)
+  expect_equal(result, expected)
+})
+
+test_that("var_d_calc calculates variance correctly with unequal sample sizes", {
+  d <- 0.8
+  n_t <- 30
+  n_c <- 45
+
+  ust_var_d <- ((n_t + n_c) / (n_t * n_c)) + ((d^2) / (2 * (n_t + n_c)))
+  hedge_g <- 1 - (3 / ((4 * (n_t + n_c - 2)) - 1))
+  expected <- round((hedge_g^2) * ust_var_d, digits = 3)
+
+  result <- var_d_calc(d = d, n_t = n_t, n_c = n_c)
+  expect_equal(result, expected)
+})
+
+test_that("var_d_calc handles small effect size", {
+  d <- 0.1
+  n_t <- 100
+  n_c <- 100
+
+  ust_var_d <- ((n_t + n_c) / (n_t * n_c)) + ((d^2) / (2 * (n_t + n_c)))
+  hedge_g <- 1 - (3 / ((4 * (n_t + n_c - 2)) - 1))
+  expected <- round((hedge_g^2) * ust_var_d, digits = 3)
+
+  result <- var_d_calc(d = d, n_t = n_t, n_c = n_c)
+  expect_equal(result, expected)
+})
+
+test_that("var_d_calc handles large effect size", {
+  d <- 2.0
+  n_t <- 20
+  n_c <- 20
+
+  ust_var_d <- ((n_t + n_c) / (n_t * n_c)) + ((d^2) / (2 * (n_t + n_c)))
+  hedge_g <- 1 - (3 / ((4 * (n_t + n_c - 2)) - 1))
+  expected <- round((hedge_g^2) * ust_var_d, digits = 3)
+
+  result <- var_d_calc(d = d, n_t = n_t, n_c = n_c)
+  expect_equal(result, expected)
+})
+
+test_that("var_d_calc handles zero effect size", {
+  d <- 0
+  n_t <- 50
+  n_c <- 50
+
+  ust_var_d <- ((n_t + n_c) / (n_t * n_c)) + ((d^2) / (2 * (n_t + n_c)))
+  hedge_g <- 1 - (3 / ((4 * (n_t + n_c - 2)) - 1))
+  expected <- round((hedge_g^2) * ust_var_d, digits = 3)
+
+  result <- var_d_calc(d = d, n_t = n_t, n_c = n_c)
+  expect_equal(result, expected)
+})
+
+test_that("var_d_calc example from documentation works", {
+  # Example from documentation
+  ditullio_results <- d_calc(stat_type = "d_i_m", stat = 5.708 - 3.0798, sample_sd = 1.0381)
+  ditullio_variance <- var_d_calc(d = ditullio_results, n_t = 38, n_c = 38)
+
+  # Check that variance is calculated and is positive
+  expect_type(ditullio_variance, "double")
+  expect_true(ditullio_variance > 0)
+
+  # Verify SE can be calculated
+  ditullio_se <- sqrt(ditullio_variance)
+  expect_true(ditullio_se > 0)
+})
+
+test_that("var_d_calc returns numeric result", {
+  result <- var_d_calc(d = 0.5, n_t = 30, n_c = 30)
+  expect_type(result, "double")
+})
+
+test_that("var_d_calc variance increases with smaller sample sizes", {
+  d <- 0.5
+  var_large_n <- var_d_calc(d = d, n_t = 100, n_c = 100)
+  var_small_n <- var_d_calc(d = d, n_t = 20, n_c = 20)
+
+  expect_true(var_small_n > var_large_n)
+})


### PR DESCRIPTION
## Summary

Adds a complete test suite using testthat with 77 passing tests covering the main package functions:

- **test-d_calc.R** (20 tests): Tests all stat_types including:
  - Direct effect sizes (d, s_m_d)
  - Standardized differences (d_i_m, d_i_d, reg_coef, regression, beta)
  - Test statistics (t_test, f_test)
  - Odds ratios (odds_ratio, log_odds_ratio)
  - Proportions (d_i_p)
  - Null results (unspecified_null)
  - Error handling for invalid types

- **test-var_d_calc.R** (10 tests): Tests variance calculations with:
  - Various effect sizes (small, large, zero)
  - Equal and unequal sample sizes
  - Documentation examples
  - Expected properties (variance increases with smaller n)

- **test-sum_tab.R** (27 tests): Tests frequency tables with:
  - Different data types (character, factor, numeric)
  - Edge cases (single value, all unique, NAs)
  - Both data frames and tibbles
  - Package datasets

- **test-study_count.R** (20 tests): Tests unique study counting with:
  - Default and custom counting variables
  - Various data structures
  - Different ID types (numeric, character, factor)
  - Package datasets

All 77 tests pass successfully.

## Test plan

- [x] All tests pass with `devtools::test()`
- [x] Added testthat to DESCRIPTION Suggests field
- [x] Tests follow testthat 3rd edition conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)